### PR TITLE
springboot-watch-pipeline to 1.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: springboot-watch-pipeline
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.2
+  version: 1.0.3


### PR DESCRIPTION
Promote springboot-watch-pipeline to version 1.0.3